### PR TITLE
fix(typings): remove union type of testAction

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,28 +17,6 @@ interface ThunkFunction {
   (fn?: Callback): ThunkFunction;
 }
 
-interface GeneratorFunction extends Function {
-  (): Generator;
-}
-
-interface GeneratorFunctionConstructor {
-  new (...args: string[]): GeneratorFunction;
-  (...args: string[]): GeneratorFunction;
-  prototype: GeneratorFunction;
-}
-
-interface IteratorResult {
-  done: boolean;
-  value: any;
-}
-
-interface Generator {
-  constructor: GeneratorFunctionConstructor;
-  next(value?: any): IteratorResult;
-  throw(err?: Error): IteratorResult;
-  return(value?: any): IteratorResult;
-}
-
 interface AsyncFunction extends Function {
   (): PromiseLike;
 }
@@ -65,11 +43,9 @@ interface SuiteAction {
   (): void;
 }
 
-interface OtherTestAction {
-  (): ThunkLikeFunction | PromiseLike | GeneratorFunction | AsyncFunction | Generator | ToThunk | ToPromise | void;
-}
+type SuitDone = (error?: any) => any;
 
-type TestAction = ThunkLikeFunction | GeneratorFunction | AsyncFunction | OtherTestAction;
+type TestAction = (done: SuitDone) => any | PromiseLike;
 
 interface SuiteFn {
   (title: string, fn: SuiteAction): tman.Suite;


### PR DESCRIPTION
没有必要写复杂的联合类型，会带来额外的麻烦。
比如:
```ts
// typeError, No best common type exists among yield expressions.
it('test should pass', function *() {
   yield Promise.resolve(1)
   yield Observable.of(1)
})
```
直接自动推断为 any 就好了
