### PR TITLE
Show diff info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules
 
 typings
 debug
+yarn.lock

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ interface ToPromise {
 }
 
 interface SuiteAction {
-  (): void;
+  (done?: SuitDone): void;
 }
 
 type SuitDone = (error?: any) => any;

--- a/lib/format.js
+++ b/lib/format.js
@@ -46,3 +46,17 @@ function style (code, str, bright) {
   if (bright) code += ';1'
   return '\x1b[' + code + 'm' + str + '\x1b[39;22m'
 }
+
+/**
+ * Color lines for `str`, using the color `name`.
+ *
+ * @api private
+ * @param {string} name
+ * @param {string} str
+ * @return {string}
+ */
+exports.colorLines = function (name, str) {
+  return str.split('\n').map(function (str) {
+    return exports[name](str)
+  }).join('\n')
+}

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -3,18 +3,17 @@
 //
 // **License:** MIT
 
+var diff = require('diff')
+var format = require('../format')
 module.exports = Reporter
 module.exports.defaultReporter = Reporter
 
 var hasOwnProperty = Object.prototype.hasOwnProperty
+var objToString = Object.prototype.toString
 
 function Reporter (ctx) {
   this.ctx = ctx
   this.count = 0
-}
-
-Reporter.hasErrExpected = function (err) {
-  return hasOwnProperty.call(err, 'actual') && hasOwnProperty.call(err, 'expected')
 }
 
 Reporter.prototype.log = function () {
@@ -46,16 +45,143 @@ Reporter.prototype.onFinish = function (rootSuite) {
   message += rootSuite.ignored + ' ignored.'
   message += ' (' + (rootSuite.endTime - rootSuite.startTime) + 'ms)\n'
   this.log(message)
-
-  rootSuite.errors.forEach(function (err) {
-    this.log(err.order + ') ' + err.title + ':')
-    if (Reporter.hasErrExpected(err)) {
-      this.log('Expected:', err.expected)
-      this.log('Actual:', err.actual)
-    }
-    this.log(err.stack ? err.stack : String(err))
-  }, this)
+  this.logError(rootSuite)
   if (rootSuite.exit && process.exit) process.exit((rootSuite.errors.length || !rootSuite.passed) ? 1 : 0)
+}
+
+Reporter.prototype.logError = function (rootSuite) {
+  rootSuite.errors.forEach(function (err, i) {
+    // msg
+    var msg
+    var message
+    if (err.message && typeof err.message.toString === 'function') {
+      message = err.message + ''
+    } else if (typeof err.inspect === 'function') {
+      message = err.inspect() + ''
+    } else {
+      message = ''
+    }
+    var stack = err.stack || message
+    var index = message ? stack.indexOf(message) : -1
+    var actual = err.actual
+    var expected = err.expected
+
+    if (index === -1) {
+      msg = message
+    } else {
+      index += message.length
+      msg = stack.slice(0, index)
+      // remove msg from stack
+      stack = stack.slice(index + 1)
+    }
+
+    // uncaught
+    if (err.uncaught) {
+      msg = 'Uncaught ' + msg
+    }
+    // explicitly show diff
+    var isShowDiff = err.showDiff !== false && sameType(actual, expected) && expected !== undefined
+    if (isShowDiff) {
+      if (!(typeof actual === 'string' && typeof expected === 'string')) {
+        err._actual = err.actual
+        err._expected = err.expected
+        err.actual = actual = typeof actual.toJSON === 'function' ? actual.toJSON() : stringify(actual)
+        err.expected = expected = typeof expected.toJSON === 'function' ? expected.toJSON() : stringify(expected)
+      }
+
+      var match = message.match(/^([^:]+): expected/)
+      msg = '\n      ' + format.gray(match ? match[1] : msg)
+
+      msg += unifiedDiff(err)
+    }
+
+    // indent stack trace
+    stack = stack.replace(/^/gm, '  ')
+    var result = errMessageFormat(isShowDiff, (i + 1), err.title, msg, stack)
+    this.log(result)
+  }, this)
+}
+
+/**
+ * Return formated error message
+ * @private
+ * @param{boolean} is diff message
+ * @param{number} index of message in Error queue
+ * @param{string} test suite title
+ * @param{string} error message
+ * @param{string} error stack
+ */
+function errMessageFormat(showDiff, pos, title, msg, stack) {
+  if (showDiff) {
+    return format.red('  '+ pos +') '+ title +':\n' + msg) + format.gray('\n'+ stack +'\n')
+  }
+  return format.red('  '+ pos +') '+ title +':\n') +
+    format.white('     ' + msg) +
+    format.white('\n'+ stack +'\n')
+}
+
+/**
+ * Returns a unified diff between two strings.
+ * @private
+ * @param {Error} err with actual/expected
+ * @return {string} The diff.
+ */
+function unifiedDiff (err) {
+  var indent = '      '
+  function cleanUp (line) {
+    if (line[0] === '+') {
+      return indent + format.colorLines('green', line)
+    }
+    if (line[0] === '-') {
+      return indent + format.colorLines('red', line)
+    }
+    if (line.match(/@@/)) {
+      return null
+    }
+    if (line.match(/\\ No newline/)) {
+      return null
+    }
+    if (line.trim().length) {
+      line = format.colorLines('white', line)
+    }
+    return indent + line
+  }
+  function notBlank (line) {
+    return typeof line !== 'undefined' && line !== null
+  }
+  var msg = diff.createPatch('string', err.actual, err.expected)
+  var lines = msg.split('\n').splice(4)
+  var diffResult = lines.map(cleanUp).filter(notBlank).join('\n')
+  if (!diffResult.trim().length) {
+    msg = diff.createPatch(
+      'string',
+      stringify(Object.keys(err._actual).sort()),
+      stringify(Object.keys(err._expected).sort())
+    )
+    lines = msg.split('\n').splice(4)
+    diffResult = format.red('       object keys not match: \n') + lines.map(cleanUp).filter(notBlank).join('\n')
+  }
+  return '\n      ' +
+    format.colorLines('green', '+ expected') + ' ' +
+    format.colorLines('red', '- actual') +
+    '\n\n' +
+    diffResult
+}
+
+/**
+ * Check that a / b have the same type.
+ *
+ * @private
+ * @param {Object} a
+ * @param {Object} b
+ * @return {boolean}
+ */
+function sameType (a, b) {
+  return objToString.call(a) === objToString.call(b)
+}
+
+function stringify (obj) {
+  return JSON.stringify(obj, Object.keys(obj).sort(), 2).replace(/,(\n|$)/g, '$1')
 }
 
 // Result: order + TAB + fulltitle + TAB + state

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -50,16 +50,7 @@ Dot.prototype.onFinish = function (rootSuite) {
   this.log(message)
   this.log(format.reset('\n\n'))
 
-  rootSuite.errors.forEach(function (err) {
-    this.log(format.indent(1) + format.red(err.order + ') ' + err.title + ':', true) + '\n')
-    if (Reporter.hasErrExpected(err)) {
-      err.expected = {a: 1}
-      this.log(util.format('%sExpected: %s\n', format.indent(2), util.inspect(err.expected)))
-      this.log(util.format('%sActual: %s\n', format.indent(2), util.inspect(err.actual)))
-    }
-    var message = err.stack ? err.stack : String(err)
-    this.log(message.replace(/^/gm, format.indent(2)) + '\n')
-  }, this)
+  this.logError(rootSuite)
   if (rootSuite.errors.length) this.log(format.reset('\n'))
   if (rootSuite.exit) process.exit((rootSuite.errors.length || !rootSuite.passed) ? 1 : 0)
 }

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -55,15 +55,7 @@ Spec.prototype.onFinish = function (rootSuite) {
   message += format.yellow(' (' + (rootSuite.endTime - rootSuite.startTime) + 'ms)', true)
   this.log(message, format.reset('\n'))
 
-  rootSuite.errors.forEach(function (err) {
-    this.log(format.indent(1) + format.red(err.order + ') ' + err.title + ':', true))
-    if (Reporter.hasErrExpected(err)) {
-      this.log(util.format('%sExpected: %s', format.indent(2), util.inspect(err.expected)))
-      this.log(util.format('%sActual: %s', format.indent(2), util.inspect(err.actual)))
-    }
-    var message = err.stack ? err.stack : String(err)
-    this.log(message.replace(/^/gm, format.indent(2)))
-  }, this)
+  this.logError(rootSuite)
   if (rootSuite.errors.length) this.log(format.reset('\n'))
   if (rootSuite.exit) process.exit((rootSuite.errors.length || !rootSuite.passed) ? 1 : 0)
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/thunks/tman",
   "dependencies": {
     "commander": "^2.9.0",
+    "diff": "^3.2.0",
     "glob": "^7.1.1",
     "supports-color": "^3.2.3",
     "thunks": "^4.7.5"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "thunks": "^4.7.5"
   },
   "devDependencies": {
+    "@types/mocha": "^2.2.39",
+    "@types/node": "^7.0.5",
     "babel-plugin-transform-async-to-generator": "^6.22.0",
     "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",

--- a/test/others.js
+++ b/test/others.js
@@ -21,6 +21,7 @@ function CustomReporter (ctx, childCtx) {
 util.inherits(CustomReporter, tman.Reporter.defaultReporter)
 CustomReporter.prototype.onFinish = function (res) {
   tman.rootSuite.passed += res.passed + res.errors.length + res.ignored
+  this.logError(res)
 }
 CustomReporter.prototype.log = function () {
   var args = slice.call(arguments)
@@ -73,6 +74,29 @@ tman.suite('Exclusive or inclusive tests', function () {
 
       t.it('test 2-2', function () {
         assert.strictEqual(count++, 2)
+      })
+
+      t.it('test 2-3', function () {
+        assert.deepEqual({
+          a: 1,
+          b: 2,
+          d: 5
+        }, {
+          a: 4,
+          b: 2,
+          c: 3
+        })
+      })
+
+      t.it('test 2-4', function () {
+        assert.deepEqual({
+          a: undefined,
+          b: 2,
+          c: 3
+        }, {
+          b: 2,
+          c: 3
+        })
       })
     })
 

--- a/test/typings.test.ts
+++ b/test/typings.test.ts
@@ -9,9 +9,9 @@ import * as assert from 'assert'
 import * as tman from '../'
 import { tman as tman1, Suite, Test, Reporter, suite, it } from '../'
 
-// tman(function () {}) // should ok
-// tman(function (done) {}) // should error
-// tman('test', function () {}) // should ok
+tman(function () {}) // should ok
+tman(function (done) {}) // should error
+tman('test', function () {}) // should ok
 
 tman.suite('tman typings', () => {
   tman.it('tman', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
   },
   "exclude": [
     "coverage",

--- a/typings.json
+++ b/typings.json
@@ -1,8 +1,0 @@
-{
-  "name": "tman",
-  "dependencies": {},
-  "globalDevDependencies": {
-    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
-    "node": "registry:dt/node#6.0.0+20160915134512"
-  }
-}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3468483/22775046/de205ee6-eee4-11e6-8c16-c6837ccabace.png)

## Notice
有一个与 mocha 不一样的行为
```javascript
assert.deepEqual({a: undefined, b: 1}, { b: 1})
```
这种断言错误在 mocha 中的输出为空，因为在 `stringify` 的时候 value 为 undefined 的 key 被丢弃了。
这个 pr 中，如果发现这种情况，则输出 `Object.keys()` 的 `diff`: https://github.com/thunks/tman/pull/4/files#diff-5c8a5788ecd4b4af2a29bc27ac4ae986R152