### PR TITLE
fix: crash when toJSON return object

### DIFF
--- a/lib/reporters/diff.js
+++ b/lib/reporters/diff.js
@@ -65,8 +65,8 @@ Diff.prototype.logError = function (rootSuite) {
       if (!(typeof actual === 'string' && typeof expected === 'string')) {
         err._actual = err.actual
         err._expected = err.expected
-        err.actual = actual = typeof actual.toJSON === 'function' ? actual.toJSON() : stringify(actual)
-        err.expected = expected = typeof expected.toJSON === 'function' ? expected.toJSON() : stringify(expected)
+        err.actual = actual = stringify(actual)
+        err.expected = expected = stringify(expected)
       }
 
       var match = message.match(/^([^:]+): expected/)

--- a/test/others.js
+++ b/test/others.js
@@ -98,6 +98,18 @@ tman.suite('Exclusive or inclusive tests', function () {
           c: 3
         })
       })
+
+      t.it('test 2-5', function () {
+        assert.deepEqual({
+          toJSON: function () {
+            return {
+              a: 5
+            }
+          }
+        }, {
+          a: 5
+        })
+      })
     })
 
     t.it('test 1-3', function () {


### PR DESCRIPTION
tman would crash if toJSON of expected/actual don't return string.

JSON.stringify will serialize the value returned by the toJSON() method.

refer [toJSON() behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior)